### PR TITLE
Slim down image to only what's necessary

### DIFF
--- a/ecr-auth-v2/Dockerfile
+++ b/ecr-auth-v2/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.13-alpine3.21
+FROM alpine3.21
 
 COPY config/.docker/config.json /root/.docker/config.json
 
-RUN apk update && apk add --no-cache docker-cli bash docker-credential-ecr-login
+RUN apk add --no-cache --update docker-cli docker-credential-ecr-login
 
-ENTRYPOINT [ "/bin/bash" ]
+ENTRYPOINT [ "/bin/sh" ]

--- a/ecr-auth-v2/ci/commands.sh
+++ b/ecr-auth-v2/ci/commands.sh
@@ -12,7 +12,7 @@ clean() {
   sudo docker builder prune -f
 }
 latestTag() {
-  [ ! -z "$1"] && echo "$1" || echo "latest"
+  [ ! -z "$1" ] && echo "$1" || echo "latest"
 }
 build() {
   local tag=$(latestTag $1)


### PR DESCRIPTION
- Uses `alpine:3.21` as base image since python isn't necessary
- Removes `apk update` command in favor of `apk add --no-cache --update`
- Removes `bash` in favor of `sh`